### PR TITLE
Update the scheduler to use Fiber.suspend

### DIFF
--- a/src/nbchannel.cr
+++ b/src/nbchannel.cr
@@ -54,7 +54,7 @@ class NBChannel(T) < Channel(T)
         @receivers.push pointerof(receiver)
         @lock.unlock
 
-        Crystal::Scheduler.reschedule
+        Fiber.suspend
 
         case receiver.state
         in .delivered?


### PR DESCRIPTION
Crystal added a new experimental feature how to schedule fibers: https://crystal-lang.org/api/1.16.3/Fiber/ExecutionContext.html.

It raises the error if enable:

```shell
$ crystal spec -Dpreview_mt -Dexecution_context
Showing last frame. Use --error-trace for full trace.

In src/nbchannel.cr:57:9

 57 | Crystal::Scheduler.reschedule
      ^-----------------
Error: undefined constant Crystal::Scheduler
```

The channel.cr was updated to support public method https://github.com/crystal-lang/crystal/blob/3f369d2c721e9462d9f6126cb0bcd4c6992f0225/src/channel.cr#L144 in [PR](https://github.com/crystal-lang/crystal/pull/14560).

I replaced `Crystal::Scheduler.reschedule` with `Fiber.suspend`.

It helps with error, but I found that the test "nonblocking receives work as expected" ([src](https://github.com/wyhaines/nbchannel.cr/blob/a8f5be6aa198abfa9f1893e1156640b8ea526094/spec/nbchannel_spec.cr#L61) ) is blocked.
It only works, if i add some `puts` in the loop. 

